### PR TITLE
tx: add interface to get gas related fields

### DIFF
--- a/wasm/legend/legendTxTypes/addLiquidityTypes.go
+++ b/wasm/legend/legendTxTypes/addLiquidityTypes.go
@@ -257,3 +257,7 @@ func (txInfo *AddLiquidityTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err err
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *AddLiquidityTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/addLiquidityTypes_test.go
+++ b/wasm/legend/legendTxTypes/addLiquidityTypes_test.go
@@ -235,6 +235,7 @@ func TestValidateAddLiquidityTxInfo(t *testing.T) {
 				GasFeeAssetId:     3,
 				GasFeeAssetAmount: big.NewInt(1),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
+				Nonce:             -1,
 			},
 		},
 		// true

--- a/wasm/legend/legendTxTypes/atomicMatchTypes.go
+++ b/wasm/legend/legendTxTypes/atomicMatchTypes.go
@@ -284,3 +284,7 @@ func (txInfo *AtomicMatchTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err erro
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *AtomicMatchTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/atomicMatchTypes_test.go
+++ b/wasm/legend/legendTxTypes/atomicMatchTypes_test.go
@@ -137,7 +137,7 @@ func TestValidateAtomicMatchTxInfo(t *testing.T) {
 				GasFeeAssetId:     3,
 				GasFeeAssetAmount: big.NewInt(100),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
-				Nonce:             0,
+				Nonce:             -1,
 			},
 		},
 	}

--- a/wasm/legend/legendTxTypes/cancelOfferTypes.go
+++ b/wasm/legend/legendTxTypes/cancelOfferTypes.go
@@ -204,3 +204,7 @@ func (txInfo *CancelOfferTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err erro
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *CancelOfferTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/cancelOfferTypes_test.go
+++ b/wasm/legend/legendTxTypes/cancelOfferTypes_test.go
@@ -111,7 +111,7 @@ func TestValidateCancelOfferTxInfo(t *testing.T) {
 				GasFeeAssetId:     3,
 				GasFeeAssetAmount: big.NewInt(100),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
-				Nonce:             0,
+				Nonce:             -1,
 			},
 		},
 		// true

--- a/wasm/legend/legendTxTypes/constants.go
+++ b/wasm/legend/legendTxTypes/constants.go
@@ -18,6 +18,7 @@
 package legendTxTypes
 
 import (
+	"math"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards/eddsa"
@@ -36,10 +37,10 @@ var (
 )
 
 const (
-	NilNonce          = 0
-	NilExpiredAt      = 0
-	NilTxAccountIndex = int64(-1)
-	NilTxAssetId      = int64(-1)
+	NilNonce        = -1
+	NilExpiredAt    = math.MaxInt64
+	NilAccountIndex = int64(-1)
+	NilAssetId      = int64(-1)
 )
 
 const (

--- a/wasm/legend/legendTxTypes/constants.go
+++ b/wasm/legend/legendTxTypes/constants.go
@@ -39,6 +39,7 @@ const (
 	NilNonce          = 0
 	NilExpiredAt      = 0
 	NilTxAccountIndex = int64(-1)
+	NilTxAssetId      = int64(-1)
 )
 
 const (

--- a/wasm/legend/legendTxTypes/createCollection.go
+++ b/wasm/legend/legendTxTypes/createCollection.go
@@ -215,3 +215,7 @@ func (txInfo *CreateCollectionTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *CreateCollectionTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/createCollection_test.go
+++ b/wasm/legend/legendTxTypes/createCollection_test.go
@@ -147,7 +147,7 @@ func TestValidateCreateCollectionTxInfo(t *testing.T) {
 				GasFeeAssetId:     3,
 				GasFeeAssetAmount: big.NewInt(100),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
-				Nonce:             0,
+				Nonce:             -1,
 			},
 		},
 		// true

--- a/wasm/legend/legendTxTypes/createPairTypes.go
+++ b/wasm/legend/legendTxTypes/createPairTypes.go
@@ -31,7 +31,7 @@ func (txInfo *CreatePairTxInfo) VerifySignature(pubKey string) error {
 }
 
 func (txInfo *CreatePairTxInfo) GetFromAccountIndex() int64 {
-	return NilTxAccountIndex
+	return NilAccountIndex
 }
 
 func (txInfo *CreatePairTxInfo) GetNonce() int64 {
@@ -47,5 +47,5 @@ func (txInfo *CreatePairTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error
 }
 
 func (txInfo *CreatePairTxInfo) GetGas() (int64, int64, *big.Int) {
-	return NilTxAccountIndex, NilTxAssetId, nil
+	return NilAccountIndex, NilAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/createPairTypes.go
+++ b/wasm/legend/legendTxTypes/createPairTypes.go
@@ -3,6 +3,7 @@ package legendTxTypes
 import (
 	"errors"
 	"hash"
+	"math/big"
 )
 
 type CreatePairTxInfo struct {
@@ -43,4 +44,8 @@ func (txInfo *CreatePairTxInfo) GetExpiredAt() int64 {
 
 func (txInfo *CreatePairTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
+}
+
+func (txInfo *CreatePairTxInfo) GetGas() (int64, int64, *big.Int) {
+	return NilTxAccountIndex, NilTxAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/depositNftTypes.go
+++ b/wasm/legend/legendTxTypes/depositNftTypes.go
@@ -39,7 +39,7 @@ func (txInfo *DepositNftTxInfo) VerifySignature(pubKey string) error {
 }
 
 func (txInfo *DepositNftTxInfo) GetFromAccountIndex() int64 {
-	return NilTxAccountIndex
+	return NilAccountIndex
 }
 
 func (txInfo *DepositNftTxInfo) GetNonce() int64 {
@@ -55,5 +55,5 @@ func (txInfo *DepositNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error
 }
 
 func (txInfo *DepositNftTxInfo) GetGas() (int64, int64, *big.Int) {
-	return NilTxAccountIndex, NilTxAssetId, nil
+	return NilAccountIndex, NilAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/depositNftTypes.go
+++ b/wasm/legend/legendTxTypes/depositNftTypes.go
@@ -53,3 +53,7 @@ func (txInfo *DepositNftTxInfo) GetExpiredAt() int64 {
 func (txInfo *DepositNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }
+
+func (txInfo *DepositNftTxInfo) GetGas() (int64, int64, *big.Int) {
+	return NilTxAccountIndex, NilTxAssetId, nil
+}

--- a/wasm/legend/legendTxTypes/depositTxTypes.go
+++ b/wasm/legend/legendTxTypes/depositTxTypes.go
@@ -45,3 +45,7 @@ func (txInfo *DepositTxInfo) GetExpiredAt() int64 {
 func (txInfo *DepositTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }
+
+func (txInfo *DepositTxInfo) GetGas() (int64, int64, *big.Int) {
+	return NilTxAccountIndex, NilTxAssetId, nil
+}

--- a/wasm/legend/legendTxTypes/depositTxTypes.go
+++ b/wasm/legend/legendTxTypes/depositTxTypes.go
@@ -31,7 +31,7 @@ func (txInfo *DepositTxInfo) VerifySignature(pubKey string) error {
 }
 
 func (txInfo *DepositTxInfo) GetFromAccountIndex() int64 {
-	return NilTxAccountIndex
+	return NilAccountIndex
 }
 
 func (txInfo *DepositTxInfo) GetNonce() int64 {
@@ -47,5 +47,5 @@ func (txInfo *DepositTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 }
 
 func (txInfo *DepositTxInfo) GetGas() (int64, int64, *big.Int) {
-	return NilTxAccountIndex, NilTxAssetId, nil
+	return NilAccountIndex, NilAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/fullExitNftTypes.go
+++ b/wasm/legend/legendTxTypes/fullExitNftTypes.go
@@ -37,7 +37,7 @@ func (txInfo *FullExitNftTxInfo) VerifySignature(pubKey string) error {
 }
 
 func (txInfo *FullExitNftTxInfo) GetFromAccountIndex() int64 {
-	return NilTxAccountIndex
+	return NilAccountIndex
 }
 
 func (txInfo *FullExitNftTxInfo) GetNonce() int64 {
@@ -53,5 +53,5 @@ func (txInfo *FullExitNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err erro
 }
 
 func (txInfo *FullExitNftTxInfo) GetGas() (int64, int64, *big.Int) {
-	return NilTxAccountIndex, NilTxAssetId, nil
+	return NilAccountIndex, NilAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/fullExitNftTypes.go
+++ b/wasm/legend/legendTxTypes/fullExitNftTypes.go
@@ -51,3 +51,7 @@ func (txInfo *FullExitNftTxInfo) GetExpiredAt() int64 {
 func (txInfo *FullExitNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }
+
+func (txInfo *FullExitNftTxInfo) GetGas() (int64, int64, *big.Int) {
+	return NilTxAccountIndex, NilTxAssetId, nil
+}

--- a/wasm/legend/legendTxTypes/fullExitTypes.go
+++ b/wasm/legend/legendTxTypes/fullExitTypes.go
@@ -45,3 +45,7 @@ func (txInfo *FullExitTxInfo) GetExpiredAt() int64 {
 func (txInfo *FullExitTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
 }
+
+func (txInfo *FullExitTxInfo) GetGas() (int64, int64, *big.Int) {
+	return NilTxAccountIndex, NilTxAssetId, nil
+}

--- a/wasm/legend/legendTxTypes/fullExitTypes.go
+++ b/wasm/legend/legendTxTypes/fullExitTypes.go
@@ -31,7 +31,7 @@ func (txInfo *FullExitTxInfo) VerifySignature(pubKey string) error {
 }
 
 func (txInfo *FullExitTxInfo) GetFromAccountIndex() int64 {
-	return NilTxAccountIndex
+	return NilAccountIndex
 }
 
 func (txInfo *FullExitTxInfo) GetNonce() int64 {
@@ -47,5 +47,5 @@ func (txInfo *FullExitTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) 
 }
 
 func (txInfo *FullExitTxInfo) GetGas() (int64, int64, *big.Int) {
-	return NilTxAccountIndex, NilTxAssetId, nil
+	return NilAccountIndex, NilAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/interface.go
+++ b/wasm/legend/legendTxTypes/interface.go
@@ -1,6 +1,9 @@
 package legendTxTypes
 
-import "hash"
+import (
+	"hash"
+	"math/big"
+)
 
 type TxInfo interface {
 	GetTxType() int
@@ -16,4 +19,6 @@ type TxInfo interface {
 	GetExpiredAt() int64
 
 	Hash(hFunc hash.Hash) (msgHash []byte, err error)
+
+	GetGas() (int64, int64, *big.Int)
 }

--- a/wasm/legend/legendTxTypes/mintNftTypes.go
+++ b/wasm/legend/legendTxTypes/mintNftTypes.go
@@ -254,3 +254,7 @@ func (txInfo *MintNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *MintNftTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/mintNftTypes_test.go
+++ b/wasm/legend/legendTxTypes/mintNftTypes_test.go
@@ -232,7 +232,7 @@ func TestValidateMintNftTxInfo(t *testing.T) {
 				GasFeeAssetId:       3,
 				GasFeeAssetAmount:   big.NewInt(100),
 				ExpiredAt:           time.Now().Add(time.Hour).UnixMilli(),
-				Nonce:               0,
+				Nonce:               -1,
 			},
 		},
 		// true

--- a/wasm/legend/legendTxTypes/offerTypes.go
+++ b/wasm/legend/legendTxTypes/offerTypes.go
@@ -229,5 +229,5 @@ func (txInfo *OfferTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 }
 
 func (txInfo *OfferTxInfo) GetGas() (int64, int64, *big.Int) {
-	return NilTxAccountIndex, NilTxAssetId, nil
+	return NilAccountIndex, NilAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/offerTypes.go
+++ b/wasm/legend/legendTxTypes/offerTypes.go
@@ -227,3 +227,7 @@ func (txInfo *OfferTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *OfferTxInfo) GetGas() (int64, int64, *big.Int) {
+	return NilTxAccountIndex, NilTxAssetId, nil
+}

--- a/wasm/legend/legendTxTypes/offerTypes_test.go
+++ b/wasm/legend/legendTxTypes/offerTypes_test.go
@@ -115,7 +115,7 @@ func TestValidateOfferTxInfo(t *testing.T) {
 			},
 		},
 		{
-			fmt.Errorf("AssetAmount should not be less than %s", minAssetAmount.String()),
+			fmt.Errorf("AssetAmount should be larger than %s", minAssetAmount.String()),
 			&OfferTxInfo{
 				Type:         1,
 				OfferId:      1,

--- a/wasm/legend/legendTxTypes/registerZnsTypes.go
+++ b/wasm/legend/legendTxTypes/registerZnsTypes.go
@@ -3,6 +3,7 @@ package legendTxTypes
 import (
 	"errors"
 	"hash"
+	"math/big"
 )
 
 type RegisterZnsTxInfo struct {
@@ -41,4 +42,8 @@ func (txInfo *RegisterZnsTxInfo) GetExpiredAt() int64 {
 
 func (txInfo *RegisterZnsTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
+}
+
+func (txInfo *RegisterZnsTxInfo) GetGas() (int64, int64, *big.Int) {
+	return NilTxAccountIndex, NilTxAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/registerZnsTypes.go
+++ b/wasm/legend/legendTxTypes/registerZnsTypes.go
@@ -29,7 +29,7 @@ func (txInfo *RegisterZnsTxInfo) VerifySignature(pubKey string) error {
 }
 
 func (txInfo *RegisterZnsTxInfo) GetFromAccountIndex() int64 {
-	return NilTxAccountIndex
+	return NilAccountIndex
 }
 
 func (txInfo *RegisterZnsTxInfo) GetNonce() int64 {
@@ -45,5 +45,5 @@ func (txInfo *RegisterZnsTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err erro
 }
 
 func (txInfo *RegisterZnsTxInfo) GetGas() (int64, int64, *big.Int) {
-	return NilTxAccountIndex, NilTxAssetId, nil
+	return NilAccountIndex, NilAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/removeLiquidityTypes.go
+++ b/wasm/legend/legendTxTypes/removeLiquidityTypes.go
@@ -298,3 +298,7 @@ func (txInfo *RemoveLiquidityTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err 
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *RemoveLiquidityTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/removeLiquidityTypes_test.go
+++ b/wasm/legend/legendTxTypes/removeLiquidityTypes_test.go
@@ -287,6 +287,7 @@ func TestValidateRemoveLiquidityTxInfo(t *testing.T) {
 				GasFeeAssetId:     3,
 				GasFeeAssetAmount: big.NewInt(1),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
+				Nonce:             -1,
 			},
 		},
 		// true

--- a/wasm/legend/legendTxTypes/swapTypes.go
+++ b/wasm/legend/legendTxTypes/swapTypes.go
@@ -275,3 +275,7 @@ func (txInfo *SwapTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *SwapTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/swapTypes_test.go
+++ b/wasm/legend/legendTxTypes/swapTypes_test.go
@@ -157,42 +157,6 @@ func TestValidateSwapTxInfo(t *testing.T) {
 				AssetBMinAmount:  big.NewInt(0).Add(maxAssetAmount, big.NewInt(1)),
 			},
 		},
-		// AssetBAmountDelta
-		{
-			fmt.Errorf("AssetBAmountDelta should not be nil"),
-			&SwapTxInfo{
-				FromAccountIndex: 1,
-				PairIndex:        1,
-				AssetAId:         1,
-				AssetAAmount:     big.NewInt(1),
-				AssetBId:         1,
-				AssetBMinAmount:  big.NewInt(1),
-			},
-		},
-		{
-			fmt.Errorf("AssetBAmountDelta should not be less than %s", minAssetAmount.String()),
-			&SwapTxInfo{
-				FromAccountIndex:  1,
-				PairIndex:         1,
-				AssetAId:          1,
-				AssetAAmount:      big.NewInt(1),
-				AssetBId:          1,
-				AssetBMinAmount:   big.NewInt(1),
-				AssetBAmountDelta: big.NewInt(-1),
-			},
-		},
-		{
-			fmt.Errorf("AssetBAmountDelta should not be larger than %s", maxAssetAmount.String()),
-			&SwapTxInfo{
-				FromAccountIndex:  1,
-				PairIndex:         1,
-				AssetAId:          1,
-				AssetAAmount:      big.NewInt(1),
-				AssetBId:          1,
-				AssetBMinAmount:   big.NewInt(1),
-				AssetBAmountDelta: big.NewInt(0).Add(maxAssetAmount, big.NewInt(1)),
-			},
-		},
 		// GasAccountIndex
 		{
 			fmt.Errorf("GasAccountIndex should not be less than %d", minAccountIndex),
@@ -309,6 +273,7 @@ func TestValidateSwapTxInfo(t *testing.T) {
 				GasFeeAssetId:     3,
 				GasFeeAssetAmount: big.NewInt(1),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
+				Nonce:             -1,
 			},
 		},
 		// true

--- a/wasm/legend/legendTxTypes/transferNftTypes.go
+++ b/wasm/legend/legendTxTypes/transferNftTypes.go
@@ -245,3 +245,7 @@ func (txInfo *TransferNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err erro
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *TransferNftTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/transferNftTypes_test.go
+++ b/wasm/legend/legendTxTypes/transferNftTypes_test.go
@@ -214,7 +214,7 @@ func TestValidateTransferNftTxInfo(t *testing.T) {
 				GasFeeAssetAmount: big.NewInt(100),
 				CallDataHash:      bytes.Repeat([]byte{1}, 32),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
-				Nonce:             0,
+				Nonce:             -1,
 			},
 		},
 	}

--- a/wasm/legend/legendTxTypes/transferTypes.go
+++ b/wasm/legend/legendTxTypes/transferTypes.go
@@ -268,3 +268,7 @@ func (txInfo *TransferTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) 
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *TransferTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/transferTypes_test.go
+++ b/wasm/legend/legendTxTypes/transferTypes_test.go
@@ -196,7 +196,7 @@ func TestValidateTransferTxInfo(t *testing.T) {
 				GasFeeAssetId:     3,
 				GasFeeAssetAmount: big.NewInt(100),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
-				Nonce:             0,
+				Nonce:             -1,
 			},
 		},
 		// ToAccountNameHash

--- a/wasm/legend/legendTxTypes/updatePairRateTypes.go
+++ b/wasm/legend/legendTxTypes/updatePairRateTypes.go
@@ -29,7 +29,7 @@ func (txInfo *UpdatePairRateTxInfo) VerifySignature(pubKey string) error {
 }
 
 func (txInfo *UpdatePairRateTxInfo) GetFromAccountIndex() int64 {
-	return NilTxAccountIndex
+	return NilAccountIndex
 }
 
 func (txInfo *UpdatePairRateTxInfo) GetNonce() int64 {
@@ -45,5 +45,5 @@ func (txInfo *UpdatePairRateTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err e
 }
 
 func (txInfo *UpdatePairRateTxInfo) GetGas() (int64, int64, *big.Int) {
-	return NilTxAccountIndex, NilTxAssetId, nil
+	return NilAccountIndex, NilAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/updatePairRateTypes.go
+++ b/wasm/legend/legendTxTypes/updatePairRateTypes.go
@@ -3,6 +3,7 @@ package legendTxTypes
 import (
 	"errors"
 	"hash"
+	"math/big"
 )
 
 type UpdatePairRateTxInfo struct {
@@ -41,4 +42,8 @@ func (txInfo *UpdatePairRateTxInfo) GetExpiredAt() int64 {
 
 func (txInfo *UpdatePairRateTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) {
 	return msgHash, errors.New("not support")
+}
+
+func (txInfo *UpdatePairRateTxInfo) GetGas() (int64, int64, *big.Int) {
+	return NilTxAccountIndex, NilTxAssetId, nil
 }

--- a/wasm/legend/legendTxTypes/withdrawNftTypes.go
+++ b/wasm/legend/legendTxTypes/withdrawNftTypes.go
@@ -220,3 +220,7 @@ func (txInfo *WithdrawNftTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err erro
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *WithdrawNftTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/withdrawNftTypes_test.go
+++ b/wasm/legend/legendTxTypes/withdrawNftTypes_test.go
@@ -194,7 +194,7 @@ func TestValidateWithdrawNftTxInfo(t *testing.T) {
 				GasFeeAssetId:          3,
 				GasFeeAssetAmount:      big.NewInt(100),
 				ExpiredAt:              time.Now().Add(time.Hour).UnixMilli(),
-				Nonce:                  0,
+				Nonce:                  -1,
 			},
 		},
 		// true

--- a/wasm/legend/legendTxTypes/withdrawTypes.go
+++ b/wasm/legend/legendTxTypes/withdrawTypes.go
@@ -227,3 +227,7 @@ func (txInfo *WithdrawTxInfo) Hash(hFunc hash.Hash) (msgHash []byte, err error) 
 	msgHash = hFunc.Sum(nil)
 	return msgHash, nil
 }
+
+func (txInfo *WithdrawTxInfo) GetGas() (int64, int64, *big.Int) {
+	return txInfo.GasAccountIndex, txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount
+}

--- a/wasm/legend/legendTxTypes/withdrawTypes_test.go
+++ b/wasm/legend/legendTxTypes/withdrawTypes_test.go
@@ -68,7 +68,7 @@ func TestValidateWithdrawTxInfo(t *testing.T) {
 			},
 		},
 		{
-			fmt.Errorf("AssetAmount should not be less than %s", minAssetAmount.String()),
+			fmt.Errorf("AssetAmount should be larger than %s", minAssetAmount.String()),
 			&WithdrawTxInfo{
 				FromAccountIndex: 1,
 				AssetId:          1,
@@ -168,7 +168,7 @@ func TestValidateWithdrawTxInfo(t *testing.T) {
 				ToAddress:         "0x299d17c8b4e9967385dc9a3bb78f2a43f5a13bd0",
 				GasFeeAssetAmount: big.NewInt(100),
 				ExpiredAt:         time.Now().Add(time.Hour).UnixMilli(),
-				Nonce:             0,
+				Nonce:             -1,
 			},
 		},
 		//  ToAddress


### PR DESCRIPTION
### Description

Add functions to get gas related fields (`gasAccountIndex`, `gastAssetId`, `gasAssetAmount`) from different txs.

### Rationale

Add functions; fix tests.

### Example
NA

### Changes

Notable changes:
* NA