### PR TITLE
circuit: fix state root verification logic because of empty tx

### DIFF
--- a/circuit/block_constraints.go
+++ b/circuit/block_constraints.go
@@ -73,9 +73,8 @@ func VerifyBlock(
 	pendingCommitmentData[2] = block.OldStateRoot
 	pendingCommitmentData[3] = block.NewStateRoot
 	api.AssertIsEqual(block.OldStateRoot, block.Txs[0].StateRootBefore)
-	isEmptyTx := api.IsZero(api.Sub(block.Txs[block.TxsCount-1].TxType, types.TxTypeEmptyTx))
-	notEmptyTx := api.IsZero(isEmptyTx)
-	types.IsVariableEqual(api, notEmptyTx, block.NewStateRoot, block.Txs[block.TxsCount-1].StateRootAfter)
+	api.AssertIsEqual(block.NewStateRoot, block.Txs[block.TxsCount-1].StateRootAfter)
+
 	onChainOpsCount = 0
 	isOnChainOp, pendingPubData, err := VerifyTransaction(api, block.Txs[0], hFunc, block.CreatedAt)
 	if err != nil {
@@ -88,9 +87,7 @@ func VerifyBlock(
 	}
 	onChainOpsCount = api.Add(onChainOpsCount, isOnChainOp)
 	for i := 1; i < block.TxsCount; i++ {
-		isEmptyTx := api.IsZero(api.Sub(block.Txs[i].TxType, types.TxTypeEmptyTx))
-		notEmptyTx := api.IsZero(isEmptyTx)
-		types.IsVariableEqual(api, notEmptyTx, block.Txs[i-1].StateRootAfter, block.Txs[i].StateRootBefore)
+		api.AssertIsEqual(block.Txs[i-1].StateRootAfter, block.Txs[i].StateRootBefore)
 		hFunc.Reset()
 		isOnChainOp, pendingPubData, err = VerifyTransaction(api, block.Txs[i], hFunc, block.CreatedAt)
 		if err != nil {

--- a/circuit/tx_constraints.go
+++ b/circuit/tx_constraints.go
@@ -546,10 +546,11 @@ func VerifyTransaction(
 	)
 	newStateRoot := hFunc.Sum()
 	types.IsVariableEqual(api, notEmptyTx, newStateRoot, tx.StateRootAfter)
+	types.IsVariableEqual(api, isEmptyTx, tx.StateRootBefore, tx.StateRootAfter);
 	return isOnChainOp, pubData, nil
 }
 
-func EmptyTx() (oTx *Tx) {
+func EmptyTx(stateRoot []byte) (oTx *Tx) {
 	oTx = &Tx{
 		TxType:            types.TxTypeEmptyTx,
 		Nonce:             0,
@@ -567,12 +568,12 @@ func EmptyTx() (oTx *Tx) {
 		LiquidityBefore:                 types.EmptyLiquidity(0),
 		NftRootBefore:                   make([]byte, 32),
 		NftBefore:                       types.EmptyNft(0),
-		StateRootBefore:                 make([]byte, 32),
+		StateRootBefore:                 stateRoot,
 		MerkleProofsAccountAssetsBefore: [NbAccountsPerTx][NbAccountAssetsPerAccount][AssetMerkleLevels][]byte{},
 		MerkleProofsAccountBefore:       [NbAccountsPerTx][AccountMerkleLevels][]byte{},
 		MerkleProofsLiquidityBefore:     [LiquidityMerkleLevels][]byte{},
 		MerkleProofsNftBefore:           [NftMerkleLevels][]byte{},
-		StateRootAfter:                  make([]byte, 32),
+		StateRootAfter:                  stateRoot,
 	}
 	for i := 0; i < NbAccountsPerTx; i++ {
 		for j := 0; j < NbAccountAssetsPerAccount; j++ {


### PR DESCRIPTION
### Description
see https://github.com/bnb-chain/zkbnb-crypto/issues/46 for details
### Rationale

tell us why we need these changes...

### Changes

Notable changes:
* Change function `EmptyTx()` signature to `EmptyTx(stateRoot []byte)`
* Add the empty state root verification logic