### PR TITLE
fix: fix creator account index of withdraw nft

### DIFF
--- a/circuit/types/withdraw_nft.go
+++ b/circuit/types/withdraw_nft.go
@@ -110,7 +110,7 @@ func VerifyWithdrawNftTx(
 	nftBefore NftConstraints,
 ) (pubData [PubDataSizePerTx]Variable) {
 	fromAccount := 0
-	creatorAccount := 0
+	creatorAccount := 1
 	pubData = CollectPubDataFromWithdrawNft(api, *tx)
 	// verify params
 	// account index


### PR DESCRIPTION
### Description

Fix creator account index of withdraw nft transaction.

### Rationale

Creator account index should be `i` in withdraw nft transactions.

### Example

NA

### Changes

Notable changes:
* fix circuits of withdraw nft 